### PR TITLE
Fix: repair invalid patterns.weekdays; defensive load + UI repair prompt

### DIFF
--- a/tests/test_invalid_weekdays_repair.py
+++ b/tests/test_invalid_weekdays_repair.py
@@ -1,0 +1,30 @@
+from datetime import date
+import sqlite3
+from kidscompass.data import Database
+from pathlib import Path
+
+
+def test_invalid_weekdays_repair(tmp_path):
+    dbf = tmp_path / 'bad.db'
+    # create DB and insert bad pattern row
+    db = Database(str(dbf))
+    cur = db.conn.cursor()
+    # Insert a bad row directly (weekdays='remove') using explicit columns
+    cur.execute("INSERT INTO patterns (weekdays, interval_weeks, start_date, end_date, label) VALUES (?,?,?,?,?)", ('remove', 1, '2024-01-01', None, 'BadRow'))
+    db.conn.commit()
+    # load_patterns should not crash and should skip bad row
+    pats = db.load_patterns()
+    assert all(getattr(p, 'weekdays', None) for p in pats) or len(pats) == 0
+    # find_bad_patterns should detect the row
+    bad = db.find_bad_patterns()
+    assert len(bad) == 1
+    # repair (quarantine)
+    report = db.repair_patterns_weekdays()
+    assert report['count'] == 1
+    # after repair, no bad patterns
+    bad2 = db.find_bad_patterns()
+    assert len(bad2) == 0
+    # load_patterns ok
+    pats2 = db.load_patterns()
+    assert isinstance(pats2, list)
+    db.close()


### PR DESCRIPTION
Problem:
App crasht beim Laden, wenn patterns.weekdays ungültige Werte enthält
(z.B. 'remove') nach Restore oder Altbestand.

Lösung:
- Database.find_bad_patterns() erkennt ungültige weekdays.
- Database.repair_patterns_weekdays(action='quarantine') erstellt DB-Backup
  und verschiebt fehlerhafte Rows nach bad_patterns, löscht sie aus patterns.
- load_patterns/find_unreferenced_patterns laden defensiv (skip + log)
  statt zu crashen.
- UI bietet beim Start/Laden einen Reparatur-Dialog an.

Tests:
- test_invalid_weekdays_repair.py
- Gesamte Testsuite: 42 passed lokal

Geänderte Dateien:
- src/kidscompass/data.py
- src/kidscompass/ui.py
- tests/test_invalid_weekdays_repair.py
